### PR TITLE
Fixed deserialization bug.

### DIFF
--- a/src/main/scala/uk/gov/voa/valuetype/play/formats/ValueTypeFormat.scala
+++ b/src/main/scala/uk/gov/voa/valuetype/play/formats/ValueTypeFormat.scala
@@ -56,12 +56,11 @@ trait ValueTypeFormat {
                                    toJson: T => JsValue) =
     new Format[V] {
 
-      def reads(json: JsValue): JsResult[V] = Try(parse(json)) match {
-        case Success(value) => JsSuccess(instantiateFromSimpleType(value))
+      def reads(json: JsValue): JsResult[V] = Try(parse(json)).flatMap(t => Try(instantiateFromSimpleType(t))) match {
+        case Success(value) => JsSuccess(value)
         case Failure(e) => JsError(e.getMessage)
       }
 
       def writes(value: V): JsValue = toJson(value.value)
-
     }
 }

--- a/src/test/scala/uk/gov/voa/valuetype/play/formats/ValueTypeFormatSpec.scala
+++ b/src/test/scala/uk/gov/voa/valuetype/play/formats/ValueTypeFormatSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.voa.valuetype.play.formats
 
 import org.scalatest.{Matchers, WordSpec}
 import play.api.libs.json.Json.{fromJson, toJson}
-import play.api.libs.json.{JsError, Json}
+import play.api.libs.json._
 import uk.gov.voa.valuetype.play.formats.ValueTypeFormat._
 import uk.gov.voa.valuetype._
 
@@ -29,15 +29,15 @@ class StringValueTypeFormatSpec extends WordSpec with Matchers {
   "StringValue.format" should {
 
     "allow to deserialize given value to json" in {
-      toJson(TestStringValue("value")) shouldBe Json.parse("\"value\"")
+      toJson(TestStringValue("value")) shouldBe JsString("value")
     }
 
     "allow deserializing json into an object" in {
-      fromJson(Json.parse("\"value\"")).get shouldBe TestStringValue("value")
+      fromJson(JsString("value")).get shouldBe TestStringValue("value")
     }
 
-    "fail deserialization when given json is invalid" in {
-      fromJson(Json.parse("1")) shouldBe a [JsError]
+    "fail deserialization when given json has the wrong type" in {
+      fromJson(JsNumber(1)) shouldBe a [JsError]
     }
   }
 }
@@ -49,15 +49,19 @@ class IntValueTypeFormatSpec extends WordSpec with Matchers {
   "IntValue.format" should {
 
     "allow to serialize given value to json" in {
-      Json.toJson(TestIntValue(1)) shouldBe Json.parse("1")
+      toJson(TestIntValue(1)) shouldBe JsNumber(1)
     }
 
     "allow deserializing json into an object" in {
-      Json.fromJson(Json.parse("1")).get shouldBe TestIntValue(1)
+      fromJson(JsNumber(1)).get shouldBe TestIntValue(1)
     }
 
-    "fail deserialization when given json is invalid" in {
-      fromJson(Json.parse("\"1\"")) shouldBe a [JsError]
+    "fail deserialization when given json has the wrong type" in {
+      fromJson(JsString("1")) shouldBe a [JsError]
+    }
+
+    "fail deserialization if the value is out of range" in {
+      fromJson(JsNumber(1L + Int.MaxValue.toLong)) shouldBe a [JsError]
     }
   }
 }
@@ -69,15 +73,16 @@ class LongValueTypeFormatSpec extends WordSpec with Matchers {
   "LongValue.format" should {
 
     "allow to serialize given value to json" in {
-      Json.toJson(TestLongValue(1)) shouldBe Json.parse("1")
+      toJson(TestLongValue(1)) shouldBe JsNumber(1)
     }
 
-    "allow deserializing json longo an object" in {
-      Json.fromJson(Json.parse("1")).get shouldBe TestLongValue(1)
+    "allow deserializing json into an object" in {
+      fromJson(JsNumber(1)).get shouldBe TestLongValue(1)
+      fromJson(JsNumber(1L + Int.MaxValue.toLong)).get shouldBe TestLongValue(1L + Int.MaxValue.toLong)
     }
 
-    "fail deserialization when given json is invalid" in {
-      fromJson(Json.parse("\"1\"")) shouldBe a [JsError]
+    "fail deserialization when given json has the wrong type" in {
+      fromJson(JsString("1")) shouldBe a [JsError]
     }
   }
 }
@@ -89,15 +94,15 @@ class BooleanValueTypeFormatSpec extends WordSpec with Matchers {
   "BooleanValue.format" should {
 
     "allow to serialize given value to json" in {
-      toJson(TestBooleanValue(true)) shouldBe Json.parse("true")
+      toJson(TestBooleanValue(true)) shouldBe JsBoolean(true)
     }
 
     "allow deserializing json into an object" in {
-      fromJson(Json.parse("false")).get shouldBe TestBooleanValue(false)
+      fromJson(JsBoolean(false)).get shouldBe TestBooleanValue(false)
     }
 
-    "fail deserialization when given json is invalid" in {
-      fromJson(Json.parse("1")) shouldBe a [JsError]
+    "fail deserialization when given json has the wrong type" in {
+      fromJson(JsNumber(0)) shouldBe a [JsError]
     }
   }
 }
@@ -109,15 +114,15 @@ class BigDecimalValueTypeFormatSpec extends WordSpec with Matchers {
   "BigDecimalValue.format" should {
 
     "allow to serialize given value to json" in {
-      toJson(TestBigDecimalValue(2.1051)) shouldBe Json.parse("2.1051")
+      toJson(TestBigDecimalValue(2.1051)) shouldBe JsNumber(2.1051)
     }
 
     "allow deserializing json into an object" in {
-      fromJson(Json.parse("2.1051")).get shouldBe TestBigDecimalValue(2.1051)
+      fromJson(JsNumber(2.1051)).get shouldBe TestBigDecimalValue(2.1051)
     }
 
-    "fail deserialization when given json is invalid" in {
-      fromJson[TestBigDecimalValue](Json.parse("\"1\"")) shouldBe a [JsError]
+    "fail deserialization when given json has the wrong type" in {
+      fromJson[TestBigDecimalValue](JsString("1")) shouldBe a [JsError]
     }
   }
 
@@ -130,15 +135,49 @@ class RoundedBigDecimalValueTypeFormatSpec extends WordSpec with Matchers {
   "BigDecimalValue.format" should {
 
     "allow to serialize given value to json" in {
-      toJson(TestRoundedBigDecimalValue(2.105)) shouldBe Json.parse("2.11")
+      toJson(TestRoundedBigDecimalValue(2.105)) shouldBe JsNumber(2.11)
     }
 
     "allow deserializing json into an object" in {
-      fromJson(Json.parse("2.105")).get shouldBe TestRoundedBigDecimalValue(2.11)
+      fromJson(JsNumber(2.105)).get shouldBe TestRoundedBigDecimalValue(2.11)
     }
 
-    "fail deserialization when given json is invalid" in {
-      fromJson[TestRoundedBigDecimalValue](Json.parse("\"1\"")) shouldBe a [JsError]
+    "fail deserialization when given json has the wrong type" in {
+      fromJson[TestRoundedBigDecimalValue](JsString("1")) shouldBe a [JsError]
+    }
+  }
+}
+
+class ValueTypeFormatSpec extends WordSpec with Matchers {
+
+  private case class Weekend(value: String) extends ValueType[String] {
+    require(value == "Saturday" || value == "Sunday")
+  }
+
+  private implicit val weekendFormat = format(Weekend)
+
+  "serializing a value type" should {
+
+    "produce the correct JSON" in {
+      toJson(Weekend("Saturday")) shouldBe JsString("Saturday")
+    }
+  }
+
+  "deserializing a value type" should {
+
+    "produce the correct object for valid JSON" in {
+      fromJson(JsString("Sunday")).get shouldBe Weekend("Sunday")
+    }
+
+    "fail when given JSON has the wrong type" in {
+      fromJson[Weekend](JsNumber(2)) shouldBe a [JsError]
+      fromJson[Weekend](JsBoolean(true)) shouldBe a [JsError]
+      fromJson[Weekend](Json.arr("Saturday", "Sunday")) shouldBe a [JsError]
+      fromJson[Weekend](Json.obj("day" -> "Saturday")) shouldBe a [JsError]
+    }
+
+    "fail when given JSON contains an invalid value" in {
+      fromJson[Weekend](JsString("Monday")) shouldBe a [JsError]
     }
   }
 }


### PR DESCRIPTION
When deserializing a value with a limited range (i.e. where all
values of the underlying primitive type weren't valid, such as an
enum), the exception produced by the class itself would be thrown, most
commonly an IllegalArgumentException.

This conversion from 'primitive' type to the valuetype is now wrapped
in a try block and returned as a JsError instead of an exception being
thrown.